### PR TITLE
fix(schema): Add missing data types

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -211,10 +211,14 @@ function getType(type) {
     case 'datetime':
     case 'float':
     case 'double':
+    case 'tinyblob':
     case 'blob':
+    case 'mediumblob':
+    case 'longblob':
     case 'date':
     case 'text':
     case 'time':
+    case 'datetime':
     case 'decimal':
       return type;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-generate-models",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Generate sails models based on your database schema.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Add missing datatypes to schema parser: tinyblob, mediumblob, longblob and datetime. Without these, the parser fails on these datatypes.

Also bump the version to 1.0.3 for npm
