### PR TITLE
Update schema.js

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -206,6 +206,7 @@ function getType(type) {
     case 'tinytext':
       return 'string';
 
+    case 'json':
     case 'longtext':
     case 'mediumtext':
     case 'datetime':


### PR DESCRIPTION
MySQL 5.7 support JSON column type, and Sails too: http://sailsjs.org/documentation/concepts/models-and-orm/attributes
