### PR TITLE
feat(schema): add column_default (defaultsTo) and referenced_table_name (model) to model attributes (column definitions)

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -54,19 +54,24 @@ Schema.prototype.getSchema = function(table, database) {
 
   return this.knex
     .select(
-      'column_name',  // name
-      'data_type',    // type
-      'extra',        // Auto increment
-      'column_key',   // index / primaryKey
-      'column_type',  // For length of int and varchar
-      'is_nullable'   // nullable (required)
+      'col.column_name',  // name
+      'col.data_type',    // type
+      'col.extra',        // Auto increment
+      'col.column_key',   // index / primaryKey
+      'col.column_type',  // For length of int and varchar
+      'col.is_nullable',   // nullable (required)
+      'col.column_default', // default value
+      'usg.referenced_table_name' // referenced model
     )
-    .from('information_schema.columns')
-    .where({
-      table_schema: database || this.options.db,
-      table_name  : table
+    .from('information_schema.columns as col')
+    .join('INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS usg', function() {
+      this.on('col.table_schema', '=', 'usg.table_schema').andOn('col.table_schema', '=', 'usg.table_schema').andOn('col.column_name', '=', 'usg.column_name')
     })
-    .orderBy('ordinal_position', 'asc')
+    .where({
+      'col.table_schema': database || this.options.db,
+      'col.table_name'  : table
+    })
+    .orderBy('col.ordinal_position', 'asc')
     .then(schema => {
       return generateModel(schema);
     });
@@ -183,6 +188,13 @@ function generateColumn(definition) {
   if (['integer', 'string'].indexOf(column.type) > -1 && size !== null) {
     column.size = parseInt(size[1]);
   }
+
+  if (!definition.column_default && definition.is_nullable.toLowerCase() === 'no') {}
+  else
+    column.defaultsTo = definition.column_default;
+
+  if (definition.referenced_table_name)
+    column.model = definition.referenced_table_name;
 
   return column;
 }


### PR DESCRIPTION
This way default values and model associations will be seen when models are generated. These were missing from the code.

Note: I admit there might be a more elegant way to do this:

```
if (!definition.column_default && definition.is_nullable.toLowerCase() === 'no') {}
else
    column.defaultsTo = definition.column_default;
```
