### PR TITLE
Sails v1 MySQL Data Models

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,22 +7,23 @@ var root   = argv.path || process.cwd();
 var Schema = require('./lib/schema');
 var path   = require('path');
 var extend = require('extend');
+var file = parseInt(require('child_process').execSync('sails -v')) < 1 ? 'connections' : 'datastores';
 var config = extend(
-  require(path.join(root, 'config/connections.js')),
-  require(path.join(root, 'config/models.js')),
-  require(path.join(root, 'config/local.js'))
+    require(path.join(root, 'config/'+ file +'.js')),
+    require(path.join(root, 'config/models.js')),
+    require(path.join(root, 'config/local.js'))
 );
 argv.path  = root;
 var knex   = require('./lib/connection')(config, argv.connection);
 var schema = new Schema(knex, argv);
 
 schema
-  .getSchema(argv.table, argv.database || knex.client.connectionSettings.database)
-  .then(schemas => {
-    return schema.write(argv.table, schemas);
-  })
-  .then(() => {
-    knex.destroy(() => {
-      console.log('> All done! Have fun with your models. :)');
-    });
-  }).catch(console.error);
+    .getSchema(argv.table, argv.database || knex.client.connectionSettings.database)
+    .then(schemas => {
+        return schema.write(argv.table, schemas);
+    })
+    .then(() => {
+        knex.destroy(() => {
+            console.log('> All done! Have fun with your models. :)');
+        });
+    }).catch(console.error);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -3,15 +3,25 @@
 var knex = require('knex');
 
 module.exports = function (config, connection) {
-  connection = config.connections[connection || config.models.connection];
 
-  return knex({
-    client: connection.adapter.replace('sails-', ''),
-    connection: {
-      host: connection.host,
-      user: connection.user,
-      password: connection.password,
-      database: connection.database,
+    if(parseInt(require('child_process').execSync('sails -v')) < 1){
+        connection = config.connections[connection || config.models.connection];
+    } else {
+        connection = require('url').parse(config.datastores.default.url);
+        connection.host = connection.hostname;
+        connection.user = connection.auth.split(':')[0];
+        connection.password = connection.auth.split(':')[1];
+        connection.database = connection.pathname.replace('/','');
+        connection.adapter = connection.protocol.replace(':','');
     }
-  });
+
+    return knex({
+        client: connection.adapter.replace('sails-', ''),
+        connection: {
+            host: connection.host,
+            user: connection.user,
+            password: connection.password,
+            database: connection.database
+        }
+    });
 };

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -78,7 +78,7 @@ Schema.prototype.getSchema = function(table, database) {
 };
 
 Schema.prototype.writeController = function(name) {
-  name = ucfirst(name)+'Controller.js';
+  name = ucwords(name)+'Controller.js';
 
   return writeFile(this.controllerDir, name, pretty(`
     /**
@@ -101,7 +101,7 @@ Schema.prototype.writeModel = function(name, schema) {
     attributes: schema
   };
 
-  name = ucfirst(name)+'.js';
+  name = ucwords(name)+'.js';
 
   return writeFile(this.modelDir, name, pretty(`
     /**
@@ -239,8 +239,10 @@ function getType(type) {
   }
 }
 
-function ucfirst(name) {
-  return name[0].toUpperCase() + name.substr(1);
+function ucwords(name) {
+  return name.replace(/_/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+      return index === 0 ? letter.toUpperCase() : letter.toUpperCase();
+  }).replace(/\s+/g, '');
 }
 
 function writeFile(dir, name, contents) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -240,8 +240,8 @@ function getType(type) {
 }
 
 function ucwords(name) {
-  return name.replace(/_/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
-      return index === 0 ? letter.toUpperCase() : letter.toUpperCase();
+  return name.replace(/_/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter) {
+      return letter.toUpperCase();
   }).replace(/\s+/g, '');
 }
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -56,6 +56,7 @@ Schema.prototype.getSchema = function(table, database) {
     .select(
       'col.column_name',  // name
       'col.data_type',    // type
+      'tbl.table_type',    // table type
       'col.extra',        // Auto increment
       'col.column_key',   // index / primaryKey
       'col.column_type',  // For length of int and varchar
@@ -66,6 +67,9 @@ Schema.prototype.getSchema = function(table, database) {
     .from('information_schema.columns as col')
     .leftJoin('INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS usg', function() {
       this.on('col.table_schema', '=', 'usg.table_schema').andOn('col.table_schema', '=', 'usg.table_schema').andOn('col.column_name', '=', 'usg.column_name')
+    })
+    .leftJoin('INFORMATION_SCHEMA.TABLES AS tbl', function() {
+        this.on('col.table_name', '=', 'tbl.table_name')
     })
     .where({
       'col.table_schema': database || this.options.db,
@@ -148,10 +152,13 @@ function generateModel(schema) {
   }
 
   schema.forEach(definition => {
-    if(definition.column_key !== 'PRI') {
-        modelAttributes[definition.column_name] = generateColumn(definition);
+    if(definition.table_type === 'VIEW'){
+        modelAttributes['id'] = { type: 'number', required: true };
+    }
+    if(definition.column_key === 'PRI') {
+        modelAttributes['id'] = generateColumn(definition);
     } else {
-      modelAttributes['id'] = generateColumn(definition);
+        modelAttributes[ucwords(definition.column_name)] = generateColumn(definition);
     }
   });
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -195,6 +195,9 @@ function generateColumn(definition) {
     required  : required
   };
 
+  if(definition.is_nullable.toLowerCase() !== 'no'){
+      column.allowNull = true;
+  }
   if(definition.data_type === 'datetime') {
       column.columnType = definition.data_type;
   }

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -96,8 +96,7 @@ Schema.prototype.writeController = function(name) {
 Schema.prototype.writeModel = function(name, schema) {
   var modelData = {
     tableName: name,
-    autoCreatedAt: false,
-    autoUpdatedAt: false,
+    schema: true,
     attributes: schema
   };
 
@@ -115,9 +114,9 @@ Schema.prototype.writeModel = function(name, schema) {
   `, {indent_size: 2}));
 };
 
-Schema.prototype.write = function(name, schema, controller) {
+Schema.prototype.write = function(name, schema) {
+  var writePromises = [];
   if (!name) {
-    var writePromises = [];
 
     Object.getOwnPropertyNames(schema).forEach(model => {
       writePromises.push(this.write(model, schema[model]));
@@ -125,8 +124,6 @@ Schema.prototype.write = function(name, schema, controller) {
 
     return Promise.all(writePromises);
   }
-
-  var writePromises = [];
 
   writePromises.push(this.writeModel(name, schema));
 
@@ -144,14 +141,18 @@ function generateModel(schema) {
 
   if (!Array.isArray(schema)) {
     Object.getOwnPropertyNames(schema).forEach(model => {
-      modelAttributes[model] = generate(schema[model]);
+      modelAttributes[model] = generateColumn(schema[model]);
     });
 
     return modelAttributes;
   }
 
   schema.forEach(definition => {
-    modelAttributes[definition.column_name] = generateColumn(definition);
+    if(definition.column_key !== 'PRI') {
+        modelAttributes[definition.column_name] = generateColumn(definition);
+    } else {
+      modelAttributes['id'] = generateColumn(definition);
+    }
   });
 
   return modelAttributes;
@@ -165,36 +166,45 @@ function generateColumn(definition) {
   };
   var size;
 
+  if(definition.data_type === 'datetime') {
+      column.columnType = definition.data_type;
+  }
+  column.columnName = definition.column_name;
+
   if (definition.extra.search('auto_increment') > -1) {
     column.autoIncrement = true;
   }
 
   if (definition.column_key.length) {
     if (definition.column_key === 'MUL') {
-      column.index = true;
+      //column.index = true;
     } else if (definition.column_key === 'PRI') {
-      column.primaryKey = true;
+      //column.primaryKey = true;
     } else if (definition.column_key === 'UNI') {
       column.unique = true;
     }
   }
 
   if (definition.data_type === 'enum') {
-    column.enum = eval('[' + definition.column_type.match(/enum\((.*?)\)/)[1] + ']');
+    column.isIn = eval('[' + definition.column_type.match(/enum\((.*?)\)/)[1] + ']');
   }
 
   size = definition.column_type.match(/\((\d+)\)/);
 
-  if (['integer', 'string'].indexOf(column.type) > -1 && size !== null) {
+  /*if (['integer', 'string'].indexOf(column.type) > -1 && size !== null) {
     column.size = parseInt(size[1]);
+  }*/
+
+  if ((definition.column_default || definition.is_nullable.toLowerCase() !== 'no') && !column.hasOwnProperty('required')) {
+    column.defaultsTo = definition.column_default || '';
   }
 
-  if (definition.column_default || definition.is_nullable.toLowerCase() !== 'no') {
-    column.defaultsTo = definition.column_default;
+  if (definition.referenced_table_name){
+      column.model = ucwords(definition.referenced_table_name);
+      delete column.type;
+      delete column.defaultsTo;
   }
 
-  if (definition.referenced_table_name)
-    column.model = definition.referenced_table_name;
 
   return column;
 }
@@ -210,18 +220,19 @@ function getType(type) {
     case 'tinyint':
     case 'timestamp':
     case 'int':
-      return 'integer';
+      return 'number';
 
     case 'char':
     case 'enum':
     case 'varchar':
     case 'tinytext':
+    case 'text':
+    case 'datetime':
+    case 'longtext':
+    case 'mediumtext':
       return 'string';
 
     case 'json':
-    case 'longtext':
-    case 'mediumtext':
-    case 'datetime':
     case 'float':
     case 'double':
     case 'tinyblob':
@@ -229,7 +240,6 @@ function getType(type) {
     case 'mediumblob':
     case 'longblob':
     case 'date':
-    case 'text':
     case 'time':
     case 'decimal':
       return type;

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -231,7 +231,6 @@ function getType(type) {
     case 'date':
     case 'text':
     case 'time':
-    case 'datetime':
     case 'decimal':
       return type;
 

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -56,6 +56,7 @@ Schema.prototype.getSchema = function(table, database) {
     .select(
       'col.column_name',  // name
       'col.data_type',    // type
+      'tbl.table_name',   // table name
       'tbl.table_type',    // table type
       'col.extra',        // Auto increment
       'col.column_key',   // index / primaryKey
@@ -98,11 +99,7 @@ Schema.prototype.writeController = function(name) {
 }
 
 Schema.prototype.writeModel = function(name, schema) {
-  var modelData = {
-    tableName: name,
-    schema: true,
-    attributes: schema
-  };
+  var modelData = schema;
 
   name = ucwords(name)+'.js';
 
@@ -141,28 +138,54 @@ Schema.prototype.write = function(name, schema) {
 
 // ===== Functions =====
 function generateModel(schema) {
-  var modelAttributes = {};
-
-  if (!Array.isArray(schema)) {
-    Object.getOwnPropertyNames(schema).forEach(model => {
-      modelAttributes[model] = generateColumn(schema[model]);
-    });
-
-    return modelAttributes;
-  }
+  var model = {}, modelAttributes = {}, relationships = [], table, identity, primaryKey, isView = false;
 
   schema.forEach(definition => {
+
+    table = definition.table_name;
+    identity = ucwords(definition.table_name).toLowerCase();
+
     if(definition.table_type === 'VIEW'){
+        isView = true;
         modelAttributes['id'] = { type: 'number', required: true };
     }
-    if(definition.column_key === 'PRI') {
-        modelAttributes['id'] = generateColumn(definition);
-    } else {
-        modelAttributes[ucwords(definition.column_name)] = generateColumn(definition);
+    modelAttributes[ucwords(definition.column_name)] = generateColumn(definition);
+
+    if (definition.column_key === 'PRI') {
+        primaryKey = ucwords(definition.column_name);
+    }
+
+    if (definition.referenced_table_name) {
+
+      var addRel = true;
+      relationships.forEach(rel => {
+          if(rel.hasOwnProperty(ucwords(definition.referenced_table_name).toLowerCase())){
+              addRel = false;
+          }
+      });
+
+      if(addRel){
+          var relationship = Object();
+          relationship[ucwords(definition.referenced_table_name).toLowerCase()] = { model: {} };
+          relationship[ucwords(definition.referenced_table_name).toLowerCase()].model = ucwords(definition.referenced_table_name).toLowerCase();
+          relationships.push(relationship);
+      }
     }
   });
 
-  return modelAttributes;
+  model = { identity: identity, tableName: table, schema: true, attributes: modelAttributes, migrate: 'safe'/*, autoPK: false, autoCreatedAt: false, autoUpdatedAt: false*/ };
+
+  if(!isView){
+      Object.assign(model, { primaryKey: primaryKey });
+  }
+
+  relationships.forEach(rel => {
+      if(rel){
+          Object.assign(model, rel);
+      }
+  });
+
+  return model;
 }
 
 function generateColumn(definition) {
@@ -171,7 +194,6 @@ function generateColumn(definition) {
     type      : getType(definition.data_type),
     required  : required
   };
-  var size;
 
   if(definition.data_type === 'datetime') {
       column.columnType = definition.data_type;
@@ -196,22 +218,9 @@ function generateColumn(definition) {
     column.isIn = eval('[' + definition.column_type.match(/enum\((.*?)\)/)[1] + ']');
   }
 
-  size = definition.column_type.match(/\((\d+)\)/);
-
-  /*if (['integer', 'string'].indexOf(column.type) > -1 && size !== null) {
-    column.size = parseInt(size[1]);
-  }*/
-
-  if ((definition.column_default || definition.is_nullable.toLowerCase() !== 'no') && !column.hasOwnProperty('required')) {
+  if ((definition.column_default || definition.is_nullable.toLowerCase() !== 'no') && !column.hasOwnProperty('required') && !definition.referenced_table_name) {
     column.defaultsTo = definition.column_default || '';
   }
-
-  if (definition.referenced_table_name){
-      column.model = ucwords(definition.referenced_table_name);
-      delete column.type;
-      delete column.defaultsTo;
-  }
-
 
   return column;
 }
@@ -257,8 +266,8 @@ function getType(type) {
 }
 
 function ucwords(name) {
-  return name.replace(/_/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter) {
-      return letter.toUpperCase();
+  return name.replace(/_/g, ' ').replace(/(?:^\w|[A-Z]|\b\w)/g, function(letter, index) {
+      return index === 0 ? letter.toLowerCase() : letter.toUpperCase();
   }).replace(/\s+/g, '');
 }
 


### PR DESCRIPTION
I created this fork in order to manage data models for Sails v1. There are some key differences between the original project. 

1. I've added data types that v1 now supports. 

2. My camel-case handling is a bit different due to how my own project needs were concerned (I have MySQL tables with underscores), so I added and am using a `ucwords` function instead of using `ucfirst `.

3. Sails v1 data models formatting has been updated along with some handling of referential data.

I haven't tested this with Sails versions earlier than v1 so I'm not completely sure of backward compatibility....hence why I haven't submitted these changes earlier. Hopefully someone can find it useful...or a stepping stone to something useful.
 
Thanks!